### PR TITLE
Fixed typo in git submodule config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/keinstein/mutabor-mode.git
 [submodule "lib/rtmidi"]
 	path = lib/rtmidi
-	url = https://github.com/keinsten/rtmidi.git
+	url = https://github.com/keinstein/rtmidi.git


### PR DESCRIPTION
There's a small typo in the git submodule configuration that prevents 'git submodule update' from working.
